### PR TITLE
@Aspect 사용 > @Around 설정

### DIFF
--- a/src/main/java/hello/aop/order/aop/AspectV1.java
+++ b/src/main/java/hello/aop/order/aop/AspectV1.java
@@ -1,0 +1,23 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+@Slf4j
+@Aspect
+public class AspectV1 {
+
+    @Around("execution(* hello.aop.order..*(..))")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        /*
+            스프링 AOP는 AspectJ의 문법을 차용하고, 프록시 방식의 AOP를 제공한다. AspectJ를 직접 사용하는 것이 아니다.
+            스프링 AOP를 사용할 때는 @Aspect 어노테이션을 주로 사용하는데, 이 어노테이션도 AspectJ가 제공하는 어노테이션이다.
+            import org.aspectj.lang.annotation.Around;
+            import org.aspectj.lang.annotation.Aspect;
+         */
+        log.info("[log] {}", joinPoint.getSignature()); // join point 시그니쳐
+        return joinPoint.proceed();
+    }
+}

--- a/src/test/java/hello/aop/AopTest.java
+++ b/src/test/java/hello/aop/AopTest.java
@@ -2,15 +2,26 @@ package hello.aop;
 
 import hello.aop.order.OrderRepository;
 import hello.aop.order.OrderService;
+import hello.aop.order.aop.AspectV1;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @Slf4j
 @SpringBootTest
+@Import(AspectV1.class)
+/*
+    @Aspect 는 표식이지 컴포넌트 스캔이 되는 것은 아니다, 따라서 AspectV1을 AOP로 사용하려면 스프링 빈으로 등록해야한다.
+    스프링 빈으로 등록하는 방법은 다음과 같다
+        @Bean을 사용하여 직접등록
+        @Component 컴포넌트 스캔을 사용해서 자동 등록
+        @Import 주로 설정 파일을 추가할 때 사용 (@Configuraion)
+    @Import는 주로 설정 파일을 추가할 때 사용하지만, 이 기능으로 스프링 빈도 등록할 수 있다. 테스트에서는 버전을 올려가면서 변경할 예정이여서 간단하게 @Import를 이번 학습에서 사용하고 있다.
+ */
 public class AopTest {
 
     @Autowired


### PR DESCRIPTION
## @Aspect @Arount 설명
스프링 AOP는 AspectJ의 문법을 차용하고, 프록시 방식의 AOP를 제공한다. AspectJ를 직접 사용하는 것이 아니다.  
스프링 AOP를 사용할 때는 @Aspect 어노테이션을 주로 사용하는데, 이 어노테이션도 AspectJ가 제공하는 어노테이션이다.  
import org.aspectj.lang.annotation.Around;  
import org.aspectj.lang.annotation.Aspect;

## Import 사용사유
- @Aspect 는 표식이지 컴포넌트 스캔이 되는 것은 아니다, 따라서 AspectV1을 AOP로 사용하려면 스프링 빈으로 등록해야한다.
- 스프링 빈으로 등록하는 방법은 다음과 같다
  - @Bean을 사용하여 직접등록
  - @Component 컴포넌트 스캔을 사용해서 자동 등록
  - @Import 주로 설정 파일을 추가할 때 사용 (@Configuraion)
- @Import는 주로 설정 파일을 추가할 때 사용하지만, 이 기능으로 스프링 빈도 등록할 수 있다. 테스트에서는 버전을 올려가면서 변경할 예정이여서 간단하게 @Import를 이번 학습에서 사용하고 있다.