### PR TITLE
스프링 AOP 구현4 포인트컷 참조

### DIFF
--- a/src/main/java/hello/aop/order/aop/AspectV4Pointcut.java
+++ b/src/main/java/hello/aop/order/aop/AspectV4Pointcut.java
@@ -1,0 +1,54 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Slf4j
+@Aspect
+public class AspectV4Pointcut {
+
+    @Around("hello.aop.order.aop.Pointcuts.allOrder()")
+    public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        /*
+            스프링 AOP는 AspectJ의 문법을 차용하고, 프록시 방식의 AOP를 제공한다. AspectJ를 직접 사용하는 것이 아니다.
+            스프링 AOP를 사용할 때는 @Aspect 어노테이션을 주로 사용하는데, 이 어노테이션도 AspectJ가 제공하는 어노테이션이다.
+            import org.aspectj.lang.annotation.Around;
+            import org.aspectj.lang.annotation.Aspect;
+         */
+        log.info("[log] {}", joinPoint.getSignature()); // join point 시그니쳐
+        return joinPoint.proceed();
+    }
+
+    // hello.aop.order 패키지와 하위 패키지 이면서 클래스 이름 패턴이 *Service 인것!
+    @Around("hello.aop.order.aop.Pointcuts.orderAndService()")
+    public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        /*
+            - allOrder() 포인트컷은 hello.aop.order 패키지와 하위 패키지를 대상으로 한다.
+            - allService() 포인트컷은 타입 이름 패턴이 *Service 를 대상으로 하는데 쉽게 이야기해서 xxxServicec처럼 service로 끝나는 명을본다 앞뒤로 * 사용도 가능하다
+            - 여기서 타입 이름 패턴이라고 한 이유는 클래스, 인터페이스에 모두 적용되기 때문이다.
+
+            ### @Around("allOrder() && allService()"
+            - 포인트컷은 이렇게 조합할 수 있다 &&, ||, ! 3가지 조합이 가능하다
+            - 결과적으로 doTransaction() 어드바이스는 현재 강의 내용에서는 OrderService에만 적용된다.
+            - doLog() 는 order하위 패키지 모두에 적용 된다.
+
+            ### 포이늩컷이 적용 된 AOP결과는 다음과 같다.
+            - orderService : doLog(), doTransaction() 어드바이스 적용
+            - orderRepository : doLog() 어드바이스 적용
+         */
+        try {
+            log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+            Object result = joinPoint.proceed();
+            log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+            return result;
+        } catch (Exception e) {
+            log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+            throw e;
+        } finally {
+            log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+        }
+    }
+}

--- a/src/main/java/hello/aop/order/aop/Pointcuts.java
+++ b/src/main/java/hello/aop/order/aop/Pointcuts.java
@@ -1,0 +1,18 @@
+package hello.aop.order.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+    // hello.aop.order 하위 패키지 모두
+    @Pointcut("execution(* hello.aop.order..*(..))")
+    public void allOrder() {}
+
+    // Service 명으로 된 클래스 모두
+    @Pointcut("execution(* *..*Service.*(..))")
+    public void allService() {}
+
+    // hello.aop.order 모두와 Service로 시작되는 패턴
+    @Pointcut("allOrder() && allService()")
+    public void orderAndService() {}
+}

--- a/src/test/java/hello/aop/AopTest.java
+++ b/src/test/java/hello/aop/AopTest.java
@@ -5,6 +5,7 @@ import hello.aop.order.OrderService;
 import hello.aop.order.aop.AspectV1;
 import hello.aop.order.aop.AspectV2;
 import hello.aop.order.aop.AspectV3;
+import hello.aop.order.aop.AspectV4Pointcut;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,8 @@ import org.springframework.context.annotation.Import;
 @SpringBootTest
 //@Import(AspectV1.class)
 //@Import(AspectV2.class)
-@Import(AspectV3.class)
+//@Import(AspectV3.class)
+@Import(AspectV4Pointcut.class)
 /*
     @Aspect 는 표식이지 컴포넌트 스캔이 되는 것은 아니다, 따라서 AspectV1을 AOP로 사용하려면 스프링 빈으로 등록해야한다.
     스프링 빈으로 등록하는 방법은 다음과 같다


### PR DESCRIPTION
## 개요
포인트컷을 공용으로 사용하기 위해 별도의 외부 클래스에 모아두어도된다. 참고로 외부에서 호출할 때는 포인트컷의 접근제한자를 public으로 열어두어야 한다.

### 사용가이드
- Pointcuts 라는 클래스 파일을 생성한다.
- @Pointcut 유형별로 메소드를을 만들어 둔다
- 어드바이스에서 Pointcuts.유형() 별로 @Around() 에 사용해서 적용한다.