### PR TITLE
스프링 AOP 구현5 어드바이스 순서변경

### DIFF
--- a/src/main/java/hello/aop/order/aop/AspectV5Order.java
+++ b/src/main/java/hello/aop/order/aop/AspectV5Order.java
@@ -1,0 +1,47 @@
+package hello.aop.order.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+
+@Slf4j
+public class AspectV5Order {
+    /*
+        ### @Aspect의 @Order 적용은 class레벨에서 적용이 가능하다!! (매우중요)
+        - 다른형태의 @Around별로 class로 분리하여 @Aspect와 @Order를 지정한다.
+        - 로그형태로 보았을 때 Service 진입 시점에 로그가 먼저찍히고!, 그 다음 Repository찍히고 outbound로 나갈 때의 순서로 찍힌다. 그림으로 쉽게 이해하겠지만 잘 생각해보아라 들어온데로 처리하고 나가는데로 처리한다.
+     */
+    @Aspect
+    @Order(2)
+    public static class LogAspect {
+        @Around("hello.aop.order.aop.Pointcuts.allOrder()")
+        @Order(2)
+        public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+            log.info("[log] {}", joinPoint.getSignature()); // join point 시그니쳐
+            return joinPoint.proceed();
+        }
+    }
+
+    @Aspect
+    @Order(1)
+    public static class TransactionAspect {
+        // hello.aop.order 패키지와 하위 패키지 이면서 클래스 이름 패턴이 *Service 인것!
+        @Around("hello.aop.order.aop.Pointcuts.orderAndService()")
+        @Order(1)
+        public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+            try {
+                log.info("[트랜잭션 시작] {}", joinPoint.getSignature());
+                Object result = joinPoint.proceed();
+                log.info("[트랜잭션 커밋] {}", joinPoint.getSignature());
+                return result;
+            } catch (Exception e) {
+                log.info("[트랜잭션 롤백] {}", joinPoint.getSignature());
+                throw e;
+            } finally {
+                log.info("[리소스 릴리즈] {}", joinPoint.getSignature());
+            }
+        }
+    }
+}

--- a/src/test/java/hello/aop/AopTest.java
+++ b/src/test/java/hello/aop/AopTest.java
@@ -6,6 +6,7 @@ import hello.aop.order.aop.AspectV1;
 import hello.aop.order.aop.AspectV2;
 import hello.aop.order.aop.AspectV3;
 import hello.aop.order.aop.AspectV4Pointcut;
+import hello.aop.order.aop.AspectV5Order;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,8 @@ import org.springframework.context.annotation.Import;
 //@Import(AspectV1.class)
 //@Import(AspectV2.class)
 //@Import(AspectV3.class)
-@Import(AspectV4Pointcut.class)
+//@Import(AspectV4Pointcut.class)
+@Import({AspectV5Order.LogAspect.class, AspectV5Order.TransactionAspect.class})
 /*
     @Aspect 는 표식이지 컴포넌트 스캔이 되는 것은 아니다, 따라서 AspectV1을 AOP로 사용하려면 스프링 빈으로 등록해야한다.
     스프링 빈으로 등록하는 방법은 다음과 같다


### PR DESCRIPTION
## 개요
어드바이스는 기본적으로 순서를 보장하지 않는다. 순서를 지정하고 싶으면 @Aspect 적용 단위로 org.springframework.core.annotation.@Order 어노테이션을 적용해야한다. 문제는 이것을 어드바이스 단위가 아니라 클래스 단위로 적용할 수 있다는 점이다. 그래서 지금처럼 하나의 에스팩트에 여러 어드바이스가 있으면 순서를 보장 받을 수 없다. 따라서 "에스팩스를 별도의 클래스로 분리" 해야한다.

현재 로그를 남기는 순서가 아마도 doLog() > doTransation() 이 순서로 남을 것이다.

로그를 남기는 순서를 바꾸어 doTransaction() > doLog() 순으로 남도록 변경한 예제이다.

## @Aspect의 @Order 적용은 class레벨에서 적용이 가능하다!! (매우중요)
- 다른형태의 @Around별로 class로 분리하여 @Aspect와 @Order를 지정한다.
- 로그형태로 보았을 때 Service 진입 시점에 로그가 먼저찍히고!, 그 다음 Repository찍히고 outbound로 나갈 때의 순서로 찍힌다. 그림으로 쉽게 이해하겠지만 잘 생각해보아라 들어온데로 처리하고 나가는데로 처리한다.