### PR TITLE
스프링 AOP this target

### DIFF
--- a/src/test/java/hello/aop/pointcut/ThisTargetTest.java
+++ b/src/test/java/hello/aop/pointcut/ThisTargetTest.java
@@ -1,0 +1,62 @@
+package hello.aop.pointcut;
+
+import hello.aop.member.MemberService;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * application.properties
+ * spring.aop.proxy-target-class=true CGLIB
+ * spring.aop.proxy-target-class=false JDK 동적 프록시
+ */
+@Slf4j
+@Import(ThisTargetTest.ThisTargetAspect.class)
+@SpringBootTest(properties = "spring.aop.proxy-target-class=true")
+//@SpringBootTest(properties = "spring.aop.proxy-target-class=false")
+public class ThisTargetTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Test
+    void success() {
+        log.info("memberService Proxy={}", memberService.getClass());
+        memberService.hello("helloA");
+    }
+
+    // 참고로 스프링트에서 프로식 사용 시 무조건 CGLIB로 동작하게되어있어서 JDK동적프록시로 돌아가게끔 별도 설정이 필요하다
+    @Slf4j
+    @Aspect
+    static class ThisTargetAspect {
+        // 부모타입을 허용
+        @Around("this(hello.aop.member.MemberService)")
+        public Object doThisInterface(ProceedingJoinPoint joinPoint) throws Throwable {
+            log.info("[this-interface] {}", joinPoint.getSignature());
+            return joinPoint.proceed();
+        }
+        // 부모타입
+        @Around("target(hello.aop.member.MemberService)")
+        public Object doTargetInterface(ProceedingJoinPoint joinPoint) throws Throwable {
+            log.info("[target-interface] {}", joinPoint.getSignature());
+            return joinPoint.proceed();
+        }
+        // 구현체타입
+        @Around("this(hello.aop.member.MemberServiceImpl)")
+        public Object doThisImpl(ProceedingJoinPoint joinPoint) throws Throwable {
+            log.info("[this-impl] {}", joinPoint.getSignature());
+            return joinPoint.proceed();
+        }
+        // 구현체타입
+        @Around("target(hello.aop.member.MemberServiceImpl)")
+        public Object doTargetImpl(ProceedingJoinPoint joinPoint) throws Throwable {
+            log.info("[target-impl] {}", joinPoint.getSignature());
+            return joinPoint.proceed();
+        }
+    }
+}


### PR DESCRIPTION
### [AOP] this, target는 스프링 프레임워크에서 사용되는 개념입니다.

- this: 메소드 실행 객체**(프록시객체)**를 참조하는 키워드입니다.
- target: 실제 메소드가 구현된 객체를 참조하는 키워드입니다.

이를 이용하여, 스프링에서 AOP를 구현할 때, 메소드 실행 전/후에 추가적인 작업을 수행할 수 있습니다.

예를 들어, 로깅 기능을 추가하고 싶다면, AOP를 활용하여 해당 메소드 실행 전/후에 로깅을 수행할 수 있습니다.

이처럼, [AOP] this, target는 스프링에서 AOP를 구현하는 데 필수적인 개념이므로, 이를 잘 이해하고 활용하는 것이 중요합니다.

this와 target은 다음과 같이 적용타입 하나를 정확하게 지정해야 한다.

```java
this(hello.aop.member.MemberService)
target(hello.aop.member.MemberService)
```

- * 같은 표현식은 사용할 수 없다.
- 부모 타입을 허용한다.
- 실제 사용성은 낮은 편인다.