### PR TITLE
스프링 AOP 실전코딩 로그trace

### DIFF
--- a/src/main/java/hello/aop/example/ExampleRepository.java
+++ b/src/main/java/hello/aop/example/ExampleRepository.java
@@ -1,0 +1,23 @@
+package hello.aop.example;
+
+import hello.aop.example.annotation.Trace;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ExampleRepository {
+
+    private static int seq = 0;
+
+    /**
+     * 5번에 1번 실패하는 요청
+     */
+    @Trace
+    public String save(String itemId) {
+        seq++;
+        if (seq % 5 == 0) {
+            throw new IllegalStateException("예외발생");
+        }
+
+        return "OK";
+    }
+}

--- a/src/main/java/hello/aop/example/ExampleService.java
+++ b/src/main/java/hello/aop/example/ExampleService.java
@@ -1,0 +1,17 @@
+package hello.aop.example;
+
+import hello.aop.example.annotation.Trace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExampleService {
+
+    private final ExampleRepository exampleRepository;
+
+    @Trace
+    public void request(String itemId) {
+        exampleRepository.save(itemId);
+    }
+}

--- a/src/main/java/hello/aop/example/annotation/Trace.java
+++ b/src/main/java/hello/aop/example/annotation/Trace.java
@@ -1,0 +1,11 @@
+package hello.aop.example.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Trace {
+}

--- a/src/main/java/hello/aop/example/aop/TraceAspect.java
+++ b/src/main/java/hello/aop/example/aop/TraceAspect.java
@@ -1,0 +1,17 @@
+package hello.aop.example.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Slf4j
+@Aspect
+public class TraceAspect {
+
+    @Before("@annotation(hello.aop.example.annotation.Trace)")
+    public void doTrace(JoinPoint joinpoint) {
+        Object[] args = joinpoint.getArgs();
+        log.info("[trace] {} args = {}", joinpoint.getSignature(), args);
+    }
+}

--- a/src/test/java/hello/aop/example/ExampleTest.java
+++ b/src/test/java/hello/aop/example/ExampleTest.java
@@ -1,0 +1,25 @@
+package hello.aop.example;
+
+import hello.aop.example.aop.TraceAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@SpringBootTest
+@Import(TraceAspect.class)
+public class ExampleTest {
+
+    @Autowired
+    ExampleService exampleService;
+
+    @Test
+    void test() {
+        for (int i = 0; i < 5; i++) {
+            log.info("client request i = {}", i);
+            exampleService.request("data" + i);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
-  어노테이션을 이용하여 특정 메소드의 param값 정보를 로그를 쌓는다

## 작업
- Trace 어노테이션 생성
  - 타켓은 메소드로 지정
  - 런타임시 적용
- Aspect 설정 추가
  - @annotation으로 조인포인트를 설정 > @Trace
  - joinpoint.getArgs() 기능으로 param값을 불러와서 로그를 찍는다
- 로그를 찍고 싶은메소드에 @Trace 어노테이션을 붙인다