### PR TITLE
스프링 AOP 실전코딩 재시도

### DIFF
--- a/src/main/java/hello/aop/example/ExampleRepository.java
+++ b/src/main/java/hello/aop/example/ExampleRepository.java
@@ -1,5 +1,6 @@
 package hello.aop.example;
 
+import hello.aop.example.annotation.Retry;
 import hello.aop.example.annotation.Trace;
 import org.springframework.stereotype.Repository;
 
@@ -12,12 +13,12 @@ public class ExampleRepository {
      * 5번에 1번 실패하는 요청
      */
     @Trace
+    @Retry(value = 4)
     public String save(String itemId) {
         seq++;
         if (seq % 5 == 0) {
             throw new IllegalStateException("예외발생");
         }
-
         return "OK";
     }
 }

--- a/src/main/java/hello/aop/example/annotation/Retry.java
+++ b/src/main/java/hello/aop/example/annotation/Retry.java
@@ -1,0 +1,13 @@
+package hello.aop.example.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retry {
+
+    int value() default 3;
+}

--- a/src/main/java/hello/aop/example/aop/RetryAspect.java
+++ b/src/main/java/hello/aop/example/aop/RetryAspect.java
@@ -1,0 +1,28 @@
+package hello.aop.example.aop;
+
+import hello.aop.example.annotation.Retry;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Slf4j
+@Aspect
+public class RetryAspect {
+
+    @Around("@annotation(retry)")
+    public Object doRetry(ProceedingJoinPoint joinPoint, Retry retry) throws Throwable {
+        int max = retry.value();
+        Exception exception = null;
+        for (int retryCount = 1; retryCount < max; retryCount++) {
+            try {
+                log.info("[retry] {} try count = {}/{}", joinPoint.getSignature(), retryCount, max);
+                return joinPoint.proceed();
+            } catch (Exception e) {
+                exception = e;
+            }
+        }
+        throw exception;
+    }
+}

--- a/src/test/java/hello/aop/example/ExampleTest.java
+++ b/src/test/java/hello/aop/example/ExampleTest.java
@@ -1,5 +1,6 @@
 package hello.aop.example;
 
+import hello.aop.example.aop.RetryAspect;
 import hello.aop.example.aop.TraceAspect;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,8 @@ import org.springframework.context.annotation.Import;
 
 @Slf4j
 @SpringBootTest
-@Import(TraceAspect.class)
+//@Import(TraceAspect.class)
+@Import({TraceAspect.class, RetryAspect.class})
 public class ExampleTest {
 
     @Autowired


### PR DESCRIPTION
## 개요
-  어노테이션을 이용하여 특정 메소드 오류 발생 시 재시도 처리

## 작업
- Retry 어노테이션 생성
  - 타켓은 메소드로 지정
  - 런타임시 적용
- Aspect 설정 추가
  - @annotation으로 조인포인트를 설정 > @Retry
  - joinPoint에서 오류가 발생하지 않으면 return되어 AOP 종료  joinPoint.proceed();
- 해당 예제는 5번 시도 때 오류가 발생되도록 Repository 설정 됨
- 5번시도 째 AOP에서 오류로 빠지고 max값만큼 재시도를 이행함